### PR TITLE
Don't build as pure C code.

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,6 +6,6 @@ from bincrafters import build_template_default
 
 if __name__ == "__main__":
 
-    builder = build_template_default.get_builder()
+    builder = build_template_default.get_builder(pure_c=False)
 
     builder.run()


### PR DESCRIPTION
This is a C++ library, so we need to build it for the various
libcxx values that may be encountered.