### PR TITLE
Make "GFLAGS_NAMESPACE" configurable

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,8 +16,8 @@ class GflagsConan(ConanFile):
     source_subfolder = "source_subfolder"
     generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False], "nothreads": [True, False]}
-    default_options = "shared=False", "fPIC=True", "nothreads=True"
+    options = {"shared": [True, False], "fPIC": [True, False], "nothreads": [True, False], "namespace": "ANY"}
+    default_options = "shared=False", "fPIC=True", "nothreads=True", "namespace=gflags"
 
     def configure(self):
         if self.settings.os == "Windows":
@@ -41,7 +41,8 @@ class GflagsConan(ConanFile):
         cmake.definitions["INSTALL_STATIC_LIBS"] = not self.options.shared
         cmake.definitions["REGISTER_BUILD_DIR"] = False
         cmake.definitions["REGISTER_INSTALL_PREFIX"] = False
-        
+        cmake.definitions["GFLAGS_NAMESPACE"] = self.options.namespace
+
         if self.settings.os != "Windows":
             cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.fPIC
         cmake.configure()

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -6,7 +6,7 @@ DEFINE_string(languages, "english,french,german",
               "comma-separated list of languages to offer in the 'lang' menu");
 
 int main(int argc, char **argv) {
-    gflags::ShowUsageWithFlags(argv[0]);
-    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ShowUsageWithFlags(argv[0]);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return 0;
 }


### PR DESCRIPTION
For example:

    conan create -o gflags:namespace="google;gflags" . bincrafters/stable

Changing the namespace like shown will require any packages depending on
this package to be rebuilt, e.g. glog. It's useful for supporting legacy
code.