### PR TITLE
Android NDK toolchain asks for a minimum Cmake check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 project(cmake_wrapper)
+cmake_minimum_required(VERSION 2.8.11)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Added a `cmake_minimum_required` check to satisfy the Android NDK CMake toolchain