### PR TITLE
Android conditional check to not link against `pthread`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -55,5 +55,5 @@ class GflagsConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Windows":
             self.cpp_info.libs.extend(['shlwapi'])
-        else:
+        elif self.settings.os != "Android":
             self.cpp_info.libs.extend(["pthread"])


### PR DESCRIPTION
`pthread` isn't a separate library on Android, and linking against it will break the build. 